### PR TITLE
Reduce container size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,40 @@
-FROM alpine
+FROM alpine AS base
+WORKDIR /app
 
+FROM base AS dependencies
 RUN apk add --update --no-cache --virtual .build \
     libsasl \
     libressl2.6-libssl \
-    libffi \
+    libffi-dev \
     yaml-dev \
     zlib-dev \
     libxslt-dev \
     libxml2-dev \
     musl-dev \
     gcc \
-    bash && \
-    apk add --no-cache \
     python-dev \
     py-pip \
     py-cffi \
     openldap-dev
 
-RUN pip install --no-cache-dir realms-wiki && \
-    apk del .build
+FROM dependencies AS build
+RUN pip install --no-cache-dir wheel && \
+    pip wheel --wheel-dir=/app/wheels realms-wiki
+
+
+FROM alpine as release
+WORKDIR /app
+COPY --from=build /app/ ./
+#NOTE: yaml-dev may be needed for reading config files; this wasn't tested.
+RUN apk add --update --no-cache \
+    python \
+    py-setuptools \
+    py-pip \
+    py-cffi \
+    openldap-dev && \
+    pip install --use-wheel --no-index --find-links=/app/wheels realms-wiki && \
+    apk del py-pip && \
+    rm -rf /app/wheels
 
 RUN addgroup \
     -S -g 1000 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine AS base
+FROM alpine:3.7 AS base
 WORKDIR /app
 
 FROM base AS dependencies
@@ -36,7 +36,7 @@ RUN pip install --no-cache-dir wheel && \
     zip -r ../${pkg} . 2>/dev/null && cd .. && rm -rf minify
 
 
-FROM alpine as release
+FROM alpine:3.7 as release
 WORKDIR /app
 COPY --from=build /app/ ./
 #NOTE: yaml-dev may be needed for reading config files; this wasn't tested.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,24 @@
 FROM alpine
 
-RUN apk update && \
-  apk add \
-    python-dev \
-    openldap-dev \
+RUN apk add --update --no-cache --virtual .build \
     libsasl \
     libressl2.6-libssl \
-    yaml-dev \
     libffi \
+    yaml-dev \
     zlib-dev \
     libxslt-dev \
     libxml2-dev \
-    py-pip \
-    py-cffi \
     musl-dev \
     gcc \
     bash && \
-  rm -rf \
-    /var/cache/apk/*
+    apk add --no-cache \
+    python-dev \
+    py-pip \
+    py-cffi \
+    openldap-dev
 
-RUN pip install realms-wiki && \
-  rm -rf \
-    /root/.cache/pip
+RUN pip install --no-cache-dir realms-wiki && \
+    apk del .build
 
 RUN addgroup \
     -S -g 1000 \
@@ -35,11 +32,11 @@ RUN addgroup \
 
 USER wiki
 
-ENV WORKERS=3
-ENV GEVENT_RESOLVER=ares
-ENV REALMS_ENV=docker
-ENV REALMS_WIKI_PATH=/data/wiki/repo
-ENV REALMS_DB_URI='sqlite:////data/db/wiki.db'
+ENV WORKERS=3 \
+    GEVENT_RESOLVER=ares \
+    REALMS_ENV=docker \
+    REALMS_WIKI_PATH=/data/wiki/repo \
+    REALMS_DB_URI='sqlite:////data/db/wiki.db'
 
 VOLUME /data/config
 VOLUME /data/db

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,11 +26,8 @@ RUN pip install --no-cache-dir wheel && \
     npm install -g uglify-js && \
     cd wheels && \
     pkg=realms_wiki*.whl && pkg=$(echo ${pkg}) && \
-    echo ${pkg} && \
     mkdir minify && cd minify && mv ../${pkg} . && \
     unzip ${pkg} 2>/dev/null && rm ${pkg} && \
-    pwd && \
-    ls -lah . && \
     echo 'minifying js. Be patient, this will take a while...' && \
     find -name '*.js' -type f -exec sh -c 'uglifyjs {} -o {}; echo minifying: {};' \; 2>/dev/null && \
     zip -r ../${pkg} . 2>/dev/null && cd .. && rm -rf minify


### PR DESCRIPTION
These commits clean up the Dockerfile, add a multi-staged build, and minify js resulting in a significant container size reduction.

Some stats:

| Commit           | Size  | Notes                                                    |
| ---              | ---   | ---                                                      |
| HEAD             | 300MB | origin/master                                            |
| (PR) cleanup     | 302MB | I still don't understand how this is bigger, but oh well |
| (PR) multi-stage | 211MB | Massive reduction from multi-stage wheel-based build     |
| (PR) js minify   | 191MB | Minifying takes a while, but reduces the size a bit      |



While it would be ideal if realms performed this minification instead of us (and just removed unecessary libraries), due to the lack of upstream updates, this is the best option we have.

Minifying the js **WILL** make your computer cry. Just close your eyes and it'll go away.

The future is now.